### PR TITLE
feat: custom query params + includeKinestex flag on content fetch API

### DIFF
--- a/kinestexsdkkotlin/src/main/java/com/kinestex/kinestexsdkkotlin/api/KinesteXAPI.kt
+++ b/kinestexsdkkotlin/src/main/java/com/kinestex/kinestexsdkkotlin/api/KinesteXAPI.kt
@@ -99,6 +99,12 @@ class KinesteXAPI(
      * @param lastDocId Optional last document ID for pagination
      * @param limit Optional limit for number of results
      * @param bodyParts Optional list of body parts to filter by
+     * @param includeKinestex Optionally controls whether KinesteX-owned content is included
+     *   by sending `include_kinestex=true|false`. When null, the parameter is omitted and the
+     *   server default applies.
+     * @param customParams Optional arbitrary query parameters appended to the request, allowing
+     *   a company to apply its own custom filtering on top of the standard parameters. Keys and
+     *   values are validated for disallowed characters.
      * @return Result containing either the requested content or an error message
      */
     suspend fun fetchAPIContentData(
@@ -109,7 +115,9 @@ class KinesteXAPI(
         category: String? = null,
         lastDocId: String? = null,
         limit: Int? = null,
-        bodyParts: List<BodyPart>? = null
+        bodyParts: List<BodyPart>? = null,
+        includeKinestex: Boolean? = null,
+        customParams: Map<String, String>? = null
     ): APIContentResult = withContext(Dispatchers.IO) {
             // Validation checks
             if (containsDisallowedCharacters(apiKey) ||
@@ -142,6 +150,14 @@ class KinesteXAPI(
                 }
             }
 
+            if (customParams != null) {
+                for ((key, value) in customParams) {
+                    if (containsDisallowedCharacters(key) || containsDisallowedCharacters(value)) {
+                        return@withContext APIContentResult.Error("⚠️ Error: Custom parameter '$key' contains disallowed characters")
+                    }
+                }
+            }
+
             // Determine endpoint
             val endpoint = when (contentType) {
                 ContentType.WORKOUT -> "workouts"
@@ -163,6 +179,8 @@ class KinesteXAPI(
                     val bodyPartsString = it.joinToString(",") { part -> part.value }
                     appendQueryParameter("body_parts", bodyPartsString)
                 }
+                includeKinestex?.let { appendQueryParameter("include_kinestex", it.toString()) }
+                customParams?.forEach { (key, value) -> appendQueryParameter(key, value) }
             }.build().toString()
 
             logger.debug("Fetching content: $contentType from $url")
@@ -177,7 +195,7 @@ class KinesteXAPI(
 
                     if (response.isSuccessful && responseBody != null) {
                         try {
-                            if (category != null || bodyParts != null || lastDocId != null) {
+                            if (category != null || bodyParts != null || lastDocId != null || customParams != null) {
                                 // Handle array responses
                                 when (contentType) {
                                     ContentType.WORKOUT -> {


### PR DESCRIPTION
## Summary

Adds two optional, **backward-compatible** parameters to `KinesteXAPI.fetchAPIContentData` so companies can apply their own filtering and control whether KinesteX-owned content is returned.

| Parameter | Type | Purpose |
|---|---|---|
| `customParams` | `Map<String, String>? = null` | Arbitrary query params appended to the request for company-specific filtering, on top of the standard params |
| `includeKinestex` | `Boolean? = null` | Emits `include_kinestex=true\|false`; omitted entirely when `null` |

## Behavior
- When unused (defaults `null`), the generated request is **identical** to before — fully source-compatible.
- `customParams` keys/values run through the existing `containsDisallowedCharacters` check; an offending param returns `APIContentResult.Error` instead of firing the request.
- Custom-filtered queries are parsed as **array responses** (added `customParams != null` to the existing filter-based list detection), matching how `category`/`bodyParts`/`lastDocId` already behave.

## Usage
```kotlin
val result = KinesteXSDK.api.fetchAPIContentData(
    contentType = ContentType.WORKOUT,
    category = "Strength",
    includeKinestex = false,
    customParams = mapOf("difficulty" to "hard", "equipment" to "dumbbell")
)
```

## Note
Client-side only. The backend must read/honor `include_kinestex` and any custom filter keys for them to affect results.

## Testing
- `./gradlew :kinestexsdkkotlin:compileReleaseKotlin` ✅ (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)