### PR TITLE
Fix list parsing for unfiltered content requests; treat blank category as no filter

### DIFF
--- a/kinestexsdkkotlin/src/main/java/com/kinestex/kinestexsdkkotlin/api/KinesteXAPI.kt
+++ b/kinestexsdkkotlin/src/main/java/com/kinestex/kinestexsdkkotlin/api/KinesteXAPI.kt
@@ -96,7 +96,8 @@ class KinesteXAPI(
      * @param id Optional unique identifier for the content
      * @param title Optional title to search for content
      * @param lang Language for the content (defaults to "en")
-     * @param category Optional category filter
+     * @param category Optional category filter. Null or blank means no filter — all
+     *   categories are returned.
      * @param lastDocId Optional last document ID for pagination
      * @param limit Optional limit for number of results
      * @param bodyParts Optional list of body parts to filter by
@@ -144,7 +145,11 @@ class KinesteXAPI(
                 }
             }
 
-            category?.let {
+            // A blank category means "no filter" — never send it to the API, where a
+            // whitespace-only value would match nothing.
+            val categoryFilter = category?.takeIf { it.isNotBlank() }
+
+            categoryFilter?.let {
                 if (containsDisallowedCharacters(it)) {
                     return@withContext APIContentResult.Error("⚠️ Error: Category contains disallowed characters")
                 }
@@ -178,7 +183,7 @@ class KinesteXAPI(
 
             val url = urlBuilder.toString().toUri().buildUpon().apply {
                 appendQueryParameter("lang", lang)
-                category?.let { appendQueryParameter("category", it) }
+                categoryFilter?.let { appendQueryParameter("category", it) }
                 lastDocId?.let { appendQueryParameter("lastDocId", it) }
                 limit?.let { appendQueryParameter("limit", it.toString()) }
                 bodyParts?.let {
@@ -201,7 +206,10 @@ class KinesteXAPI(
 
                     if (response.isSuccessful && responseBody != null) {
                         try {
-                            if (category != null || bodyParts != null || lastDocId != null || customParams != null) {
+                            // A request without an id or title is a list request — the API
+                            // returns {workouts: [...], lastDocId} regardless of which
+                            // filters (if any) were applied.
+                            if (id == null && title == null) {
                                 // Handle array responses
                                 when (contentType) {
                                     ContentType.WORKOUT -> {


### PR DESCRIPTION
## Problem

A client could not fetch **all** their workouts. Calling `fetchAPIContentData(contentType = WORKOUT)` with no category built the correct list URL, but the SDK parsed the `{workouts: [...], lastDocId}` list response as a **single workout** — Gson silently produced an all-null model, so the result looked empty.

Root cause: the list-vs-single parsing branch keyed off which *filter* params were set (`category`/`bodyParts`/`lastDocId`/`customParams`). The response shape is actually determined by the request form alone: **no `id` and no `title` ⇒ the API returns a paginated list** — for workouts, plans, and exercises alike.

## Changes

- Parse as a list whenever `id == null && title == null` (fixes unfiltered list fetches for all three content types, and also id+filter combos that were previously mis-parsed as lists).
- Treat blank `category` (`""` or whitespace) as "no filter" and never send it — an empty value relied on the server dropping it, and a whitespace-only value would filter to nothing.
- KDoc updated accordingly.

## Verification

- `:kinestexsdkkotlin:compileReleaseKotlin` passes.
- Server behavior verified live against `admin.kinestex.com`: no-category and empty-category list requests return the identical unfiltered `{workouts, lastDocId}` page; a non-empty category filters correctly.

Fetching everything now works with the natural call:

```kotlin
KinesteXSDK.api.fetchAPIContentData(
    contentType = ContentType.WORKOUT,
    limit = 50,
    includeKinestex = false,
)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)